### PR TITLE
Registrywatcher

### DIFF
--- a/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
+++ b/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
@@ -76,6 +76,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
+++ b/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
@@ -90,6 +90,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="System.Management" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Resource Include="Application.ico" />
     <Resource Include="Resources\searchDefault.png" />
     <Resource Include="Resources\controlsBack.png" />

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/RegistryEventWatcher.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/RegistryEventWatcher.cs
@@ -1,0 +1,57 @@
+﻿using CairoDesktop.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management;
+using System.Security.Principal;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CairoDesktop.SupportingClasses
+{
+    public sealed class RegistryEventWatcher : IDisposable
+    {
+        private const string REGISTRY_HIVE = @"HKEY_USERS";
+        private const string REGISTRY_VALUE = @"AccentColorMenu";
+        private const string REGISTRY_KEY = @"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Accent";
+
+        private readonly ManagementEventWatcher _watcher;
+        private readonly CairoApplicationThemeService _themeService;
+
+        public RegistryEventWatcher(CairoApplicationThemeService ts)
+        {
+            WqlEventQuery query = new WqlEventQuery(GetQuery());
+            _watcher = new ManagementEventWatcher(query);
+            _themeService = ts;
+            WatchRegistry(true);
+            _watcher.Start();
+        }
+
+        private String GetQuery()
+        {
+            WindowsIdentity currentUser = WindowsIdentity.GetCurrent();
+            return $"SELECT * FROM RegistryValueChangeEvent WHERE Hive = '{REGISTRY_HIVE}' AND KeyPath = '{currentUser.User.Value}\\\\{REGISTRY_KEY}' AND ValueName = '{REGISTRY_VALUE}'";
+        }
+
+        public void WatchRegistry(bool subscribe)
+        {
+            _watcher.EventArrived -= new EventArrivedEventHandler(SystemEvents_RegistryChanged);
+            if (subscribe)
+            {
+                _watcher.EventArrived += new EventArrivedEventHandler(SystemEvents_RegistryChanged);
+            }
+        }
+
+        private void SystemEvents_RegistryChanged(object sender, EventArrivedEventArgs e)
+        {
+            _themeService.SetThemeFromSettings();
+        }
+
+        public void Dispose()
+        {
+            this.WatchRegistry(false);
+            this._watcher.Stop();
+            this._watcher.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Merging the two, a non-breaking change that improves the performance of theme switching

[+] Replaced SystemEvents with a WMI query, as it asynchronously checks for registry value change in the accent color value, thus preventing multiple calls to the theme reloading method each time a theme is changed. This is due to the SystemEvents handling the theme color as a generic category, just like the theme and the wallpaper.